### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <repositories>
         <repository>
             <id>aksw-internal</id>
-            <url>http://maven.aksw.org/repository/internal/</url>
+            <url>https://maven.aksw.org/repository/internal/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -68,7 +68,7 @@
         </repository>
          <repository>
              <id>aksw-snapshots</id>
-             <url>http://maven.aksw.org/repository/snapshots/</url>
+             <url>https://maven.aksw.org/repository/snapshots/</url>
              <releases>
                  <enabled>true</enabled>
              </releases>


### PR DESCRIPTION
Resolve dependencies of the AKSW repository over https.